### PR TITLE
Add monthly cron to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: '0 1 * * 4'
 
 jobs:
   build:


### PR DESCRIPTION
This provides a weekly check of the unit tests to make sure the interface is still waterinfo.be compatible, as we do not have any information on updates,... from the waterinfo side.