### PR TITLE
Switch to hic base url as in online documentation provided by HIC

### DIFF
--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -19,7 +19,7 @@ other KIWIS-python clients:
 
 VMM_BASE = "https://download.waterinfo.be/tsmdownload/KiWIS/KiWIS"
 VMM_AUTH = "http://download.waterinfo.be/kiwis-auth/token"
-HIC_BASE = "https://www.waterinfo.be/tsmhic/KiWIS/KiWIS"
+HIC_BASE = "https://hicws.vlaanderen.be/KiWIS/KiWIS"
 HIC_AUTH = "https://hicwsauth.vlaanderen.be/auth"
 DATA_PATH = pkg_resources.resource_filename(__name__, "/data")
 


### PR DESCRIPTION
See https://hicws.vlaanderen.be/Manual_for_the_use_of_webservices_HIC.pdf and #19 using https://hicws.vlaanderen.be/KiWIS/KiWIS as the HIC base url. Should not influence the token handling