### PR TITLE
Time zone support

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -58,6 +58,25 @@ In case you already know the :code:`ts_id` identifier that defines your time ser
 Mostly, you do not know these identifiers. Hence, to search for the required identifiers, different methods are
 provided to support this, as described in the following sections.
 
+The datetime inputs (:code:`start` and :code:`end`) are assumed to be 'UTC' by
+default. To request data in another (supported) time zone (e.g. :code:`CET`, :code:`GMT`,
+:code:`Etc/GMT+1`,...), add the :code:`timezone` parameter, e.g. :code:`timezone='CET'`.
+
+.. warning::
+
+    This behavior is different to the KIWIS API itself, which interprets the incoming
+    date format always as :code:`CET`. Hence, requesting data to the REST API directly
+    from '2019-05-01 14:00:00' with timezone 'UTC' will return data starting
+    from '2019-05-01 12:00:00+00' (UTC). In the pywaterinfo package, the
+    :code:`start` and :code:`end` parameters are assumed in the timezone of the request
+    parameter :code:`timezone` (unless the :code:`start` and :code:`end` already contain
+    time zone info).
+
+Apart from the :code:`start` and :code:`end` configuration, the usage of the :code:`period` is a convenient
+way of requesting time series. See the :func:`~pywaterinfo.Waterinfo.get_timeseries_values` for
+more information and examples.
+
+
 Time series groups
 ------------------
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -76,6 +76,10 @@ Apart from the :code:`start` and :code:`end` configuration, the usage of the :co
 way of requesting time series. See the :func:`~pywaterinfo.Waterinfo.get_timeseries_values` for
 more information and examples.
 
+.. note::
+
+    If you want 'naive' timestamps in the returned time series, use the :code:`tz_localize`
+    function of Pandas, e.g. :code:`df["Timestamp"] = df["Timestamp"].dt.tz_localize(None)`.
 
 Time series groups
 ------------------

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -171,7 +171,13 @@ class Waterinfo:
         if "returnfields" in query.keys():
             self._check_return_fields_format(query["returnfields"], query["request"])
 
-        query.update(self.__default_args)
+        # User can overwrite the default arguments
+        defaults = {
+            key: value
+            for (key, value) in self.__default_args.items()
+            if key not in query.keys()
+        }
+        query.update(defaults)
         if not headers:
             headers = dict()
         if self._token_header:

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -306,7 +306,7 @@ class Waterinfo:
             )
 
     @staticmethod
-    def _parse_date(input_datetime, timezone=None):
+    def _parse_date(input_datetime, timezone="UTC"):
         """Evaluate date and transform to format accepted by KIWIS API
 
         Dates can be specified on a courser-than-day basis, but will always be
@@ -324,9 +324,9 @@ class Waterinfo:
         ----------
         input_datetime : str
             datetime string
+        timezone : str, default 'UTC'
+            user defined timezone to use
         """
-        if not timezone:
-            timezone = "UTC"
         if timezone not in pytz.all_timezones:
             raise pytz.exceptions.UnknownTimeZoneError(
                 f"{timezone} is not a valid timezone string."
@@ -343,7 +343,7 @@ class Waterinfo:
                 .strftime("%Y-%m-%d %H:%M:%S")
             )
 
-    def _parse_period(self, start=None, end=None, period=None, timezone=None):
+    def _parse_period(self, start=None, end=None, period=None, timezone="UTC"):
         """Check the from/to/period arguments when requesting (valid for
         getTimeseriesValues and getGraph)
 
@@ -366,8 +366,8 @@ class Waterinfo:
             valid datetime string representation as defined in the KIWIS getRequestInfo
         period : str
             period input string according to format required by waterinfo
-        timezone: str
-            User defined custom timezone to use.
+        timezone: str, default 'UTC'
+            User defined timezone to use.
 
         Returns
         -------
@@ -499,7 +499,7 @@ class Waterinfo:
         if "timezone" in kwargs.keys():
             timezone = kwargs["timezone"]
         else:
-            timezone = None
+            timezone = "UTC"
 
         # check the period information
         period_info = self._parse_period(

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -332,12 +332,16 @@ class Waterinfo:
                 f"{timezone} is not a valid timezone string."
             )
 
-        return (
-            pd.to_datetime(input_datetime)
-            .tz_localize(timezone)
-            .tz_convert("CET")
-            .strftime("%Y-%m-%d %H:%M:%S")
-        )
+        input_timestamp = pd.to_datetime(input_datetime)
+
+        if input_timestamp.tz:  # timestamp already contains tz info
+            return input_timestamp.tz_convert("CET").strftime("%Y-%m-%d %H:%M:%S")
+        else:
+            return (
+                input_timestamp.tz_localize(timezone)
+                .tz_convert("CET")
+                .strftime("%Y-%m-%d %H:%M:%S")
+            )
 
     def _parse_period(self, start=None, end=None, period=None, timezone=None):
         """Check the from/to/period arguments when requesting (valid for

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -418,7 +418,7 @@ class Waterinfo:
         Each identifier ts_id corresponds to a given variable-location-frequency
         combination (e.g. precipitation, Waregem, daily). When interested in daily,
         monthly, yearly aggregates look for these identifiers in order to overcome
-        too much/large requests.
+        too many/large requests.
 
         Note: The usage of 'start' and 'end' instead of the API default from/to is done
         to avoid the usage of from, which is a protected name in Python.
@@ -473,6 +473,10 @@ class Waterinfo:
         >>> # Note: UTC as time unit is used as input and asked as output by default
         >>> df = vmm.get_timeseries_values("60992042,60968042",
         ...                           start="20190502", end="20190503")
+        >>>
+        >>> # One can overwrite the timezone to request data in another time zone:
+        >>> df = vmm.get_timeseries_values("60992042,60968042",
+        ...                           start="20190502", end="20190503", timezone="CET")
         >>>
         >>> # get the data for all stations from groups 192900 (yearly rain sum)
         >>> # and 192895 (yearly discharge average) for the last 2 years

--- a/tests/test_waterinfo.py
+++ b/tests/test_waterinfo.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 
 import pytest
 
 import pandas as pd
+import pytz
 from pandas.api import types
 from pandas.api.types import is_datetime64tz_dtype
 
@@ -177,13 +179,16 @@ class TestPeriodDates:
             vmm_connection._parse_period(end="2013-12-01", period="P3D").keys()
         ) == set(["to", "period"])
 
-    def test_date_formats(self, vmm_connection):
+
+class TestDatetimeHandling:
+    def test_input_date_formats_utc_default(self, vmm_connection):
         """Date formats accepted as UTC, but provided to API as CET in order to get
         the time series as UTC
 
-        Input datetime of the KIWIS API is always CET (and is not tz-aware), but we
-        normalize everything to UTC. Hence, we interpret the package user input as UTC,
-        provide the input to the API as CET and request the returned output data as UTC.
+        Input datetime of the KIWIS API is always CET (and is not tz-aware), but (by
+        default) we normalize everything to UTC. Hence, we interpret the package user
+        input as UTC, provide the input to the API as CET and request the returned
+        output data as UTC.
         """
         assert vmm_connection._parse_date("2017-01-01") == "2017-01-01 01:00:00"
         assert vmm_connection._parse_date("2017-08-01") == "2017-08-01 02:00:00"
@@ -197,7 +202,7 @@ class TestPeriodDates:
         )
         assert vmm_connection._parse_date("01-01-2017") == "2017-01-01 01:00:00"
 
-    def test_utc_return(self, df_timeseries):
+    def test_utc_default_return(self, df_timeseries):
         """Check that the returned dates are UTC aware and according to the user
         input in UTC
         """
@@ -210,6 +215,94 @@ class TestPeriodDates:
         )
         assert types.is_datetime64tz_dtype(pd.to_datetime(df_timeseries["Timestamp"]))
         assert pd.to_datetime(df_timeseries.loc[0, "Timestamp"]).tz.zone == "UTC"
+
+    def test_kiwis_requires_cet(self, vmm_connection, caplog):
+        """Check on the KIWIS behavior of CET date format as request parameter
+
+        When using the KIWIS API, the input date format is always CET, whereas the
+        output data format can be requested. In pywaterinfo, we change this behavior
+        so when requesting a timezone, the input date format is assumed in this format
+        as well and the query will be adjusted as such.
+        """
+        # Requesting data at CET 14h should equal requesting data at UTC 16h (+2h)
+        with caplog.at_level(logging.INFO):
+            df_utc = vmm_connection.get_timeseries_values(
+                ts_id="60992042",
+                start="20190501 14:05:00",
+                end="20190501 14:10:00",
+                returnfields="Timestamp,Value",
+                timezone="UTC",
+            )
+            assert "timezone=UTC" in caplog.text
+            # from/to request parameter adjusted to link input date format to timezone
+            assert "from=2019-05-01+16%3A05%3A00" in caplog.text
+            assert "to=2019-05-01+16%3A10%3A00" in caplog.text
+        caplog.clear()
+
+        with caplog.at_level(logging.INFO):
+            df_cet = vmm_connection.get_timeseries_values(
+                ts_id="60992042",
+                start="20190501 16:05:00",
+                end="20190501 16:10:00",
+                returnfields="Timestamp,Value",
+                timezone="CET",
+            )
+            assert "timezone=CET" in caplog.text
+            assert "from=2019-05-01+16%3A05%3A00" in caplog.text
+            assert "to=2019-05-01+16%3A10%3A00" in caplog.text
+        caplog.clear()
+        pd.testing.assert_series_equal(
+            df_utc["Timestamp"], df_cet["Timestamp"].dt.tz_convert("UTC")
+        )
+        pd.testing.assert_series_equal(df_utc["Value"], df_cet["Value"])
+
+    def test_input_date_formats_custom_timezone(self, vmm_connection):
+        """User provides custom timezone for date inputs and returned time series
+
+        Input datetime of the KIWIS API is always CET (and is not tz-aware). When a user
+        defines a custom time zone-, input date is interpreted as the custom timezone,
+        request is sent as CET and returned data is converted to custom timezone
+        provided by the user.
+
+        Note, there is no query option to check the timezone string for the java
+        app of kisters, so we only check if string is supported by pytz.
+        """
+        df_utc_default = vmm_connection.get_timeseries_values(
+            ts_id="60992042", start="20190501 14:05", end="20190501 14:10"
+        )
+        df_utc = vmm_connection.get_timeseries_values(
+            ts_id="60992042",
+            start="20190501 14:05",
+            end="20190501 14:10",
+            timezone="UTC",
+        )
+        # UTC data should be the same as CET, taken into accoutn 2h difference
+        df_cet = vmm_connection.get_timeseries_values(
+            ts_id="60992042",
+            start="20190501 16:05",
+            end="20190501 16:10",
+            timezone="CET",
+        )
+        pd.testing.assert_series_equal(df_utc_default["Timestamp"], df_utc["Timestamp"])
+        pd.testing.assert_series_equal(
+            df_cet["Timestamp"].dt.tz_convert("UTC"), df_utc["Timestamp"]
+        )
+
+    def test_overwrite_timezone(self, vmm_connection):
+        """Check if timezone is overwritten"""
+        df = vmm_connection.get_timeseries_values(
+            ts_id="60992042", start="20190501 14:05", end="20190501 14:10"
+        )
+        assert df["Timestamp"].dt.tz == pytz.UTC
+
+        df = vmm_connection.get_timeseries_values(
+            ts_id="60992042",
+            start="20190501 14:05",
+            end="20190501 14:10",
+            timezone="CET",
+        )
+        assert is_datetime64tz_dtype(df["Timestamp"])
+        assert df["Timestamp"].dt.tz == pytz.FixedOffset(120)
 
     def test_return_date_format(self, vmm_connection):
         """Input to requested return date format should be existing on KIWIS API"""


### PR DESCRIPTION
Extend the support for time zone handling of the pywaterinfo API by properly supporting the `timezone` request parameter when requesting time series, e.g. using the CET time zone:

```
from pywaterinfo import Waterinfo
vmm = Waterinfo("vmm")

df = vmm.get_timeseries_values(
    ts_id="60992042", start="20190501 14:05:00", end="20190501 14:10:00",
    returnfields="Timestamp,Value", timezone="CET"
)
df.head()
```
The `start` and `end` dates are converted to the given time zone `CET` and the timezone is added to the API request. The output is returned with the offset information:

|    | Timestamp                 |   Value |    ts_id |
|---:|:--------------------------|--------:|---------:|
|  0 | 2019-05-01 14:05:00+02:00 |       0 | 60992042 |
|  1 | 2019-05-01 14:06:00+02:00 |       0 | 60992042 |
|  2 | 2019-05-01 14:07:00+02:00 |       0 | 60992042 |
|  3 | 2019-05-01 14:08:00+02:00 |       0 | 60992042 |
|  4 | 2019-05-01 14:09:00+02:00 |       0 | 60992042 |

which van be converted to naive datetime if preferred, using Pandas:

```
df["Timestamp"] = df["Timestamp"].dt.tz_localize(None)
```


@arnoutr does this properly support your use case at https://github.com/fluves/pywaterinfo/issues/12 ?