### PR TITLE
Fix deprecation warning on loading pkgresources with relative path

### DIFF
--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -25,7 +25,7 @@ VMM_BASE = "https://download.waterinfo.be/tsmdownload/KiWIS/KiWIS"
 VMM_AUTH = "http://download.waterinfo.be/kiwis-auth/token"
 HIC_BASE = "https://hicws.vlaanderen.be/KiWIS/KiWIS"
 HIC_AUTH = "https://hicwsauth.vlaanderen.be/auth"
-DATA_PATH = pkg_resources.resource_filename(__name__, "/data")
+DATA_PATH = pkg_resources.resource_filename(__name__, "./data")
 
 # Custom hard-coded fix for the decoding issue #1 of given returnfields
 DECODE_ERRORS = ["AV Quality Code Color", "RV Quality Code Color"]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -15,10 +15,17 @@ def test_cache_vmm(vmm_connection):
 def test_cache_hic(hic_connection):
     """Second call of the same request is retrieved from cache for HIC requests."""
     hic_connection.clear_cache()
-    data, res = hic_connection.request_kiwis({"request": "getRequestInfo"})
+    data, res = hic_connection.request_kiwis(
+        query={"request": "getTimeseriesValueLayer", "timeseriesgroup_id": "156207"}
+    )
     assert not res.from_cache
-    data, res = hic_connection.request_kiwis({"request": "getRequestInfo"})
+    data, res = hic_connection.request_kiwis(
+        query={"request": "getTimeseriesValueLayer", "timeseriesgroup_id": "156207"}
+    )
     assert res.from_cache
+
+
+{"request": "getTimeseriesValueLayer", "timeseriesgroup_id": "156207"}
 
 
 def test_clear_cache(vmm_connection):
@@ -37,7 +44,7 @@ def test_cache_retention(patch_retention):
     Uses monkeypatch version of the CACHE_RETENTION timing for unit testing.
     """
     vmm = Waterinfo("vmm")
-    data, res = vmm.request_kiwis({"request": "getRequestInfo"})
+    _, _ = vmm.request_kiwis({"request": "getRequestInfo"})
 
     time.sleep(2)
     data, res = vmm.request_kiwis({"request": "getRequestInfo"})

--- a/tests/test_waterinfo.py
+++ b/tests/test_waterinfo.py
@@ -446,10 +446,15 @@ class TestRequestKiwis:
 
 class TestTimeseriesValueLayer:
     def test_one_of_three(self, vmm_connection):
+        """Should be either ts_id, bbox or timeseriesgroup_id"""
         with pytest.raises(Exception):
             vmm_connection.get_timeseries_value_layer(
                 ts_id="78124042", timeseriesgroup_id="192900", bbox="DUMMY"
             )
+
+    def test_hic(self, hic_connection):
+        df = hic_connection.get_timeseries_value_layer(timeseriesgroup_id="156207")
+        assert "ts_id" in df.columns
 
 
 class TestGroupList:
@@ -462,6 +467,10 @@ class TestGroupList:
         with pytest.raises(Exception):
             vmm_connection.get_group_list(group_type="DUMMY")
 
+    def test_hic(self, hic_connection):
+        df = hic_connection.get_group_list()
+        assert "group_id" in df.columns
+
 
 class TestTimeseriesList:
     def test_no_data(self, vmm_connection):
@@ -469,3 +478,8 @@ class TestTimeseriesList:
         assert vmm_connection.get_timeseries_list(station_no="DUMMY").equals(
             pd.DataFrame([])
         )
+
+    def test_hic(self, hic_connection):
+        """"""
+        df = hic_connection.get_timeseries_list(station_no="plu03a-1066")
+        assert "station_no" in df.columns


### PR DESCRIPTION
While checking why the scheduled ci run fails, I encountered depr warning on pkgresources; fixed by this PR.

__note__ the ci failures on the HIC cache -> locally works with pytest but not inside tox (py37); request is just not cached inside tox 37. need to check further