### PR TITLE
Fix requests retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         fail-fast: [false]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,13 @@ jobs:
     - name: Test with pytest
       env:
         HIC_TOKEN: ${{ secrets.HIC_TOKEN }}
+        VMM_TOKEN: ${{ secrets.VMM_TOKEN }}
       run: |
         pytest
     - name: Test with tox
       env:
         HIC_TOKEN: ${{ secrets.HIC_TOKEN }}
+        VMM_TOKEN: ${{ secrets.VMM_TOKEN }}
       run: |
         tox
     - name: Test doctests

--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
-
+venv
 .vscode
 
 # ignore sqlite

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     pandas
     requests
-    requests-cache
+    requests-cache>=0.8
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -126,9 +126,7 @@ class Waterinfo:
 
         # clean up cache old entries (requests-cache only removes/updates
         # entries that are reused, so this remove piling too much cache.)
-        self._request.remove_expired_responses(
-            datetime.datetime.utcnow() - CACHE_RETENTION
-        )
+        self._request.remove_expired_responses(CACHE_RETENTION)
 
     def __repr__(self):
         return f"<{self.__class__.__name__} object, " f"Query from {self._base_url!r}>"

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -126,7 +126,7 @@ class Waterinfo:
 
         # clean up cache old entries (requests-cache only removes/updates
         # entries that are reused, so this remove piling too much cache.)
-        self._request.cache.remove_expired_responses(
+        self._request.remove_expired_responses(
             datetime.datetime.utcnow() - CACHE_RETENTION
         )
 

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -7,8 +7,6 @@ import pytz
 import re
 import requests
 import requests_cache
-import tempfile
-from pathlib import Path
 
 """
 INFO:
@@ -75,9 +73,11 @@ class Waterinfo:
 
         # Use requests-cache session
         self._request = requests_cache.CachedSession(
-            cache_name=Path(tempfile.gettempdir()) / "pywaterinfo_cache.sqlite",
+            cache_name="pywaterinfo_cache.sqlite",
             backend="sqlite",
             expire_after=CACHE_RETENTION,
+            stale_if_error=False,
+            use_temp=True,
         )
 
         self.__default_args = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ hic_client = os.environ.get("HIC_TOKEN")
 
 @pytest.fixture
 def patch_retention(monkeypatch):
-    retention = datetime.timedelta(seconds=1)
+    retention = datetime.timedelta(seconds=0.01)
     monkeypatch.setattr("pywaterinfo.waterinfo.CACHE_RETENTION", retention)
 
 

--- a/tests/test_waterinfo.py
+++ b/tests/test_waterinfo.py
@@ -57,10 +57,7 @@ def test_token_vmm():
 
     # token, token header, authentication in request header
     # this client code is received by VMM for unit testing purposes only
-    client = (
-        "MzJkY2VlY2UtODI2Yy00Yjk4LTljMmQtYjE2OTc4ZjBjYTZhOjRhZGE"
-        "4NzFhLTk1MjgtNGI0ZC1iZmQ1LWI1NzBjZThmNGQyZA=="
-    )
+    client = os.environ.get("VMM_TOKEN")
     vmm = Waterinfo("vmm", token=client)
     vmm.clear_cache()
     assert vmm._token_header is not None

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ allowlist_externals = pytest
 setenv =
     TOXINIDIR = {toxinidir}
 passenv =
-    HOME HIC_TOKEN
+    HOME HIC_TOKEN VMM_TOKEN
 extras =
     develop
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ name = pywaterinfo
 
 [tox]
 minversion = 3.15
-envlist = py36,py37,py38,py39
+envlist = py37,py38,py39
 skip_missing_interpreters=true
 
 


### PR DESCRIPTION
Current weekly builds fail due to updates in the requests-cache package to cache the URL's. This PR updates the unit tests and make sure current code is in line with the new version while keeping the functionality for pywaterinfo the same.