### PR TITLE
Change author order

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,6 +3,11 @@ title: pywaterinfo
 message: 'If you use this software, please cite it as below.'
 type: software
 authors:
+  - given-names: Stijn
+    family-names: ' Van Hoey'
+    email: stijn@fluves.com
+    affiliation: Fluves
+    orcid: 'https://orcid.org/0000-0001-6413-3185'
   - given-names: Johan
     name-particle: 'van de '
     family-names: Wauw
@@ -13,12 +18,6 @@ authors:
     family-names: Maiheu
     affiliation: VMM
     orcid: 'https://orcid.org/0000-0002-9175-1306'
-  - given-names: Stijn
-    name-particle: 'Van '
-    family-names: Hoey
-    email: stijn@fluves.com
-    affiliation: Fluves
-    orcid: 'https://orcid.org/0000-0001-6413-3185'
 repository-code: 'https://github.com/fluves/pywaterinfo'
 url: 'https://fluves.github.io/pywaterinfo/'
 repository-artifact: 'https://pypi.org/project/pywaterinfo/'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,12 +4,12 @@ message: 'If you use this software, please cite it as below.'
 type: software
 authors:
   - given-names: Stijn
-    family-names: ' Van Hoey'
+    family-names: 'Van Hoey'
     email: stijn@fluves.com
     affiliation: Fluves
     orcid: 'https://orcid.org/0000-0001-6413-3185'
   - given-names: Johan
-    name-particle: 'van de '
+    name-particle: Van de'
     family-names: Wauw
     email: johan@fluves.com
     affiliation: Fluves

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,7 @@ authors:
     affiliation: Fluves
     orcid: 'https://orcid.org/0000-0001-6413-3185'
   - given-names: Johan
-    name-particle: Van de'
-    family-names: Wauw
+    family-names: 'Van de Wauw'
     email: johan@fluves.com
     affiliation: Fluves
     orcid: 'https://orcid.org/0000-0003-0150-3315'


### PR DESCRIPTION
@johanvdw this might represent the implementation order more than the original version. 

With regard to the 'name particle', I checked the [guidelines](https://citation-file-format.github.io/assets/pdf/cff-specifications-1.0-RC1.pdf) and some online resources. Apparently, the lowercase of 'van der' should be a name particle, whereas the uppercase 'Van' (Hoey) is part of the last name field. I adjusted as such.