### PR TITLE
Add support for datetime with zoneinfo tzinfo

### DIFF
--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -344,7 +344,7 @@ class Waterinfo:
         we normalize everything to UTC by default. Hence, we interpret the user
         input as UTC, provide the input to the API as CET and request the returned
         output data as UTC. If the user provides a timezone, we interpret user input as
-        the given timezone, doe the request in CET and return th output data in the
+        the given timezone, do the request in CET and return the output data in the
         requested timezone.
 
         Parameters
@@ -359,16 +359,12 @@ class Waterinfo:
                 f"{timezone} is not a valid timezone string."
             )
 
-        input_timestamp = pd.to_datetime(input_datetime)
+        input_timestamp = pd.to_datetime(str(input_datetime))
 
-        if input_timestamp.tz:  # timestamp already contains tz info
-            return input_timestamp.tz_convert("CET").strftime("%Y-%m-%d %H:%M:%S")
-        else:
-            return (
-                input_timestamp.tz_localize(timezone)
-                .tz_convert("CET")
-                .strftime("%Y-%m-%d %H:%M:%S")
-            )
+        if not input_timestamp.tz:  # timestamp does not contain tz info
+            input_timestamp = input_timestamp.tz_localize(timezone)
+        
+        return input_timestamp.tz_convert("CET").strftime("%Y-%m-%d %H:%M:%S")
 
     def _parse_period(self, start=None, end=None, period=None, timezone="UTC"):
         """Check the from/to/period arguments when requesting


### PR DESCRIPTION
### Description
[`pandas` is currently not compatible with the `zoneinfo` module of the Python standard library](https://github.com/pandas-dev/pandas/issues/37654) (new in version 3.9). This affects `pywaterinfo` through the use of `pandas.to_datetime` method in `waterinfo._parse_dates`.

### Example Error
```
from pywaterinfo import Waterinfo
from datetime import datetime
from zoneinfo import ZoneInfo

dt = datetime(2022, 1, 1, tzinfo=ZoneInfo("Europe/Brussels"))
df = Waterinfo('vmm').get_timeseries_values("78073042", start=dt, end=dt, timezone="Europe/Brussels")

> Exception ignored in: 'pandas._libs.tslibs.conversion._localize_tso'
> Traceback (most recent call last):
> File "pandas\_libs\tslibs\timezones.pyx", line 266, in pandas._libs.tslibs.timezones.get_dst_info
> AttributeError: 'NoneType' object has no attribute 'total_seconds'
```
Note that a `pandas.DataFrame` is still returned to `df`, although it contains unexpected results for this case. This is due to `pandas.to_datetime` returning a correctly offset (for UTC wall time), but naive timestamp (i.e. `2021-12-31 23:00:00`) instead of the expected aware timestamp (i.e. `2022-01-01 00:00:00+01:00`). Because of the implementation of `waterinfo._parse_dates`, this naive timestamp is then localized to the provided time zone, resulting in an incorrect timestamp (i.e. `2021-12-31 23:00:00+01:00`).

### Proposed Solution
By converting `input_datetime` (string or `datetime.datetime` object) to a string before applying `pandas.to_datetime`, compatibility issues between `pandas` and `zoneinfo` are circumvented by relying on the correct implementation of `datetime.__str__()`.

### Other
Corrected typos and duplicate code for `waterinfo._parse_date`.