### PR TITLE
Add support for datetime with zoneinfo tzinfo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,13 @@ exclude: '^docs/conf.py'
 
 repos:
 - repo: https://github.com/psf/black
-  rev: 21.9b0
+  rev: 21.12b0
   hooks:
     - id: black
       language_version: python3.7
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
@@ -30,6 +30,6 @@ repos:
     args: ['--max-line-length=88']  # default of Black
 
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.9.3
+  rev: v5.10.1
   hooks:
   - id: isort

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -344,7 +344,7 @@ class Waterinfo:
         we normalize everything to UTC by default. Hence, we interpret the user
         input as UTC, provide the input to the API as CET and request the returned
         output data as UTC. If the user provides a timezone, we interpret user input as
-        the given timezone, doe the request in CET and return th output data in the
+        the given timezone, do the request in CET and return the output data in the
         requested timezone.
 
         Parameters
@@ -359,16 +359,12 @@ class Waterinfo:
                 f"{timezone} is not a valid timezone string."
             )
 
-        input_timestamp = pd.to_datetime(input_datetime)
+        input_timestamp = pd.to_datetime(str(input_datetime))
 
-        if input_timestamp.tz:  # timestamp already contains tz info
-            return input_timestamp.tz_convert("CET").strftime("%Y-%m-%d %H:%M:%S")
-        else:
-            return (
-                input_timestamp.tz_localize(timezone)
-                .tz_convert("CET")
-                .strftime("%Y-%m-%d %H:%M:%S")
-            )
+        if not input_timestamp.tz:  # timestamp does not contain tz info
+            input_timestamp = input_timestamp.tz_localize(timezone)
+        
+        return input_timestamp.tz_convert("CET").strftime("%Y-%m-%d %H:%M:%S")
 
     def _parse_period(self, start=None, end=None, period=None, timezone="UTC"):
         """Check the from/to/period arguments when requesting

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -363,7 +363,7 @@ class Waterinfo:
 
         if not input_timestamp.tz:  # timestamp does not contain tz info
             input_timestamp = input_timestamp.tz_localize(timezone)
-        
+
         return input_timestamp.tz_convert("CET").strftime("%Y-%m-%d %H:%M:%S")
 
     def _parse_period(self, start=None, end=None, period=None, timezone="UTC"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ hic_client = os.environ.get("HIC_TOKEN")
 
 @pytest.fixture
 def patch_retention(monkeypatch):
-    retention = datetime.timedelta(seconds=0.01)
+    retention = datetime.timedelta(seconds=0.0001)
     monkeypatch.setattr("pywaterinfo.waterinfo.CACHE_RETENTION", retention)
 
 


### PR DESCRIPTION
Identical to https://github.com/fluves/pywaterinfo/pull/46, but from my forks `datetime` branch instead of its `main` one.
Thanks for the suggestions @stijnvanhoey!