### PR TITLE
Update CI with recent 

### DIFF
--- a/.github/workflows/binder.yml
+++ b/.github/workflows/binder.yml
@@ -7,24 +7,22 @@ on:
 jobs:
   Create-Binder-Badge:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-
-    - name: checkout pull request branch
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-
     - name: comment on PR with Binder link
-      uses: actions/github-script@v1
+      uses: actions/github-script@v6
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          var BRANCH_NAME = process.env.BRANCH_NAME;
-          github.issues.createComment({
+          var PR_HEAD_USERREPO = process.env.PR_HEAD_USERREPO;
+          var PR_HEAD_REF = process.env.PR_HEAD_REF;
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${context.repo.owner}/${context.repo.repo}/${BRANCH_NAME}) :point_left: Launch a binder notebook on this branch`
+            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}) :point_left: Launch a binder notebook on branch _${PR_HEAD_USERREPO}/${PR_HEAD_REF}_`
           })
       env:
-        BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_HEAD_USERREPO: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
         fail-fast: [false]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
         fail-fast: [false]
 
     steps:
@@ -34,7 +34,7 @@ jobs:
       run: |
         python -m pip install --upgrade pre-commit
         pre-commit run --all-files
-      if: matrix.python-version == '3.7'
+      if: matrix.python-version == '3.9'
     - name: Test with pytest
       env:
         HIC_TOKEN: ${{ secrets.HIC_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
         fail-fast: [false]
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.7'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
 name: Upload Python Package
-
 on:
   release:
     types: [created]
-
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get all git tags
       run: git fetch --prune --unshallow --tags
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Install dependencies

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.7'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -7,11 +7,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get all git tags
       run: git fetch --prune --unshallow --tags
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   rev: 23.1.0
   hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.9
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,13 @@ exclude: '^docs/conf.py'
 
 repos:
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 23.1.0
   hooks:
     - id: black
       language_version: python3.7
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.4.0
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
@@ -23,8 +23,8 @@ repos:
   - id: mixed-line-ending
     args: ['--fix=no']
 
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/pycqa/flake8
+  rev: 6.0.0
   hooks:
   - id: flake8
     args: ['--max-line-length=88']  # default of Black

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,8 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Intended Audience :: Science/Research
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -165,7 +165,7 @@ class Waterinfo:
         >>> # get the API info/documentation from kiwis
         >>> data, res = vmm.request_kiwis({"request": "getRequestInfo"})
         >>> data        #doctest: +ELLIPSIS
-        [{'Title': 'KISTERS QueryServices - Request Inform...file'}}}}}}]
+        [{'Title': 'KISTERS QueryServices - Request Inform...}}}}}]
         >>> res.status_code
         200
         >>> # get the timeseries data from last day from time series 78124042

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -245,7 +245,7 @@ class Waterinfo:
         else:
             optional_parameters = set()
 
-        for (parameter, _) in query.items():
+        for parameter, _ in query.items():
             if parameter not in (
                 supported_parameters | optional_parameters | set(self._default_params)
             ):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -70,8 +70,8 @@ def test_cache_retention(patch_retention):
     assert not res.from_cache
 
     time.sleep(1)
-    vmm = Waterinfo("vmm")
     _, res = vmm.request_kiwis({"request": "getRequestInfo"})
+    print(res.from_cache, res.created_at, res.expires, res.is_expired)
     assert res.is_expired
 
     vmm._request.remove_expired_responses()

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ name = pywaterinfo
 
 [tox]
 minversion = 3.15
-envlist = py37,py38,py39
+envlist = py37,py38,py39,py310,py311
 skip_missing_interpreters=true
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,9 @@ allowlist_externals = pytest
 setenv =
     TOXINIDIR = {toxinidir}
 passenv =
-    HOME,HIC_TOKEN,VMM_TOKEN
+    HOME
+    HIC_TOKEN
+    VMM_TOKEN
 extras =
     develop
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ name = pywaterinfo
 
 [tox]
 minversion = 3.15
-envlist = py37,py38,py39,py310,py311
+envlist = py{37,38,39,310,311}
 skip_missing_interpreters=true
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ allowlist_externals = pytest
 setenv =
     TOXINIDIR = {toxinidir}
 passenv =
-    HOME HIC_TOKEN VMM_TOKEN
+    HOME,HIC_TOKEN,VMM_TOKEN
 extras =
     develop
 commands =


### PR DESCRIPTION
Add Python 3.10/3.11 to CI setup to check if all tests run. If so, we can support these more recent versions. I also updated the CI step of the binder-link to make it work on PRs from forks (which should fix the CI failure on https://github.com/fluves/pywaterinfo/pull/59).