### PR TITLE
Refactor cache to make it opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[develop]
+        pip install -e .[develop,cache]
     - name: Run precommit hooks & linting
       if: matrix.python-version == '3.9'
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[develop]
+        pip install -e .[develop,cache]
         pip install setuptools wheel twine
     - name: Build documentation
       run: |

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[develop]
+        pip install -e .[develop,cache]
     - name: Build documentation
       run: |
         tox -e docs

--- a/docs/cache.rst
+++ b/docs/cache.rst
@@ -3,7 +3,13 @@
 Caching
 =======
 
-To overcome redundant requests of the same data to the waterinfo endpoints, the package relies on the `requests-cache <https://pypi.org/project/requests-cache/>`_ package to cache the :code:`GET` requests.
+To overcome redundant requests of the same data to the waterinfo endpoints, the package relies on the `requests-cache <https://pypi.org/project/requests-cache/>`_ package to cache the :code:`GET` requests. The
+cache feature is opt-in (not activated by default), but can be activated by the initialization of the ``Waterinfo`` class:
+
+::
+
+    from pywaterinfo import Waterinfo
+    vmm = Waterinfo("vmm", cache=True)
 
 The cache is stored in a sqlite database called :code:`pywaterinfo_cache.sqlite` and the default retention time of the cache is 7 days.
 When you want to make sure to not use a cached requests, make sure to empty the cache first using the :func:`~pywaterinfo.Waterinfo.clear_cache` method:

--- a/docs/cache.rst
+++ b/docs/cache.rst
@@ -1,10 +1,17 @@
 
+.. _cache:
 
 Caching
 =======
 
 To overcome redundant requests of the same data to the waterinfo endpoints, the package relies on the `requests-cache <https://pypi.org/project/requests-cache/>`_ package to cache the :code:`GET` requests. The
-cache feature is opt-in (not activated by default), but can be activated by the initialization of the ``Waterinfo`` class:
+cache feature is opt-in (not installed/activated by default), but can be used after installing the cache dependency packages:
+
+::
+
+    pip install pywaterinfo[cache]
+
+To use the cache, activate it on the initialization of the ``Waterinfo`` class:
 
 ::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,6 +13,14 @@ The package releases are available on `Pypi <https://pypi.org/>`_. To install th
 
     pip install pywaterinfo
 
+To use caching to overcome redundant requests to the waterinfo APi, install the cache dependencies:
+
+::
+
+    pip install pywaterinfo[cache]
+
+See :ref:`cache` documentation for more information on the caching feature.
+
 
 Using setuptools
 ----------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     pandas
     requests
-    requests-cache>=0.8
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
@@ -59,6 +58,8 @@ exclude =
 # Add here additional requirements for extra features, to install with:
 # `pip install pywaterinfo[PDF]` like:
 # PDF = ReportLab; RXP
+cache = requests-cache>=0.8
+
 # Add here test requirements (semicolon/line-separated)
 develop =
     tox

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -6,7 +6,14 @@ import pandas as pd
 import pytz
 import re
 import requests
-import requests_cache
+
+try:
+    import requests_cache
+
+    request_cache_support = True
+except ImportError:
+    request_cache_support = False
+
 
 """
 INFO:
@@ -72,6 +79,8 @@ class Waterinfo:
             same data are stored in a local cache.
         """
 
+        # TODO - add info on missing installation of requests-cache
+
         # set the base string linked to the data provider
         if provider == "vmm":
             self._base_url = VMM_BASE
@@ -86,16 +95,23 @@ class Waterinfo:
 
         # Use requests-cache session
         if cache:
-            self._cache = True
-            self._request = requests_cache.CachedSession(
-                cache_name="pywaterinfo_cache.sqlite",
-                use_memory=False,
-                cache_control=True,
-                expire_after=CACHE_RETENTION,
-                stale_if_error=False,
-                use_cache_dir=True,
-                proxies=proxies,
-            )
+            if request_cache_support:
+                self._cache = True
+                self._request = requests_cache.CachedSession(
+                    cache_name="pywaterinfo_cache.sqlite",
+                    use_memory=False,
+                    cache_control=True,
+                    expire_after=CACHE_RETENTION,
+                    stale_if_error=False,
+                    use_cache_dir=True,
+                    proxies=proxies,
+                )
+            else:
+                raise Exception(
+                    "The required packages to support caching are not "
+                    "installed. Install them with "
+                    "`pip install pywaterinfo[cache]`."
+                )
         else:
             self._cache = False
             self._request = requests.Session()

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -156,7 +156,8 @@ class Waterinfo:
 
     def clear_cache(self):
         """Clean up the cache."""
-        self._request.cache.clear()
+        if self._cache:
+            self._request.cache.clear()
 
     def request_kiwis(self, query: dict, headers: dict = None) -> dict:
         """http call to waterinfo.be KIWIS API
@@ -239,8 +240,16 @@ class Waterinfo:
         if self._cache:
             if res.from_cache:
                 logging.info(f"Request {res.url} reused from cache.")
+            else:
+                logging.info(
+                    f"Successful waterinfo API request with call {res.url} "
+                    f"(call to waterinfo.be with cache activated)."
+                )
         else:
-            logging.info(f"Successful waterinfo API request with call {res.url}")
+            logging.info(
+                f"Successful waterinfo API request with call {res.url} "
+                f"(call to waterinfo.be with without cache activated)."
+            )
 
         parsed = res.json()
         if (

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -67,6 +67,9 @@ class Waterinfo:
             Dictionary mapping protocol or protocol and host to the URL of the proxy
             (e.g. {‘http’: ‘foo.bar:3128’, ‘http://host.name’: ‘foo.bar:4012’}) to be
             used on each Request
+        cache : bool, default False
+            If True, a cached session is used to make sure consecutive calls for the
+            same data are stored in a local cache.
         """
 
         # set the base string linked to the data provider

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -87,7 +87,7 @@ class Waterinfo:
             self._request = requests_cache.CachedSession(
                 cache_name="pywaterinfo_cache.sqlite",
                 use_memory=False,
-                cache_control=False,
+                cache_control=True,
                 expire_after=CACHE_RETENTION,
                 stale_if_error=False,
                 use_cache_dir=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,11 +30,30 @@ def vmm_connection():
 
 
 @pytest.fixture(scope="module")
+def vmm_cached_connection():
+    session = Waterinfo("vmm", token=vmm_client, cache=True)
+    session.clear_cache()
+    return session
+
+
+@pytest.fixture(scope="module")
 def hic_connection():
     if hic_client:
         return Waterinfo("hic", token=hic_client)
     else:
         return Waterinfo("hic")
+
+
+@pytest.fixture(scope="module")
+def hic_cached_connection():
+    if hic_client:
+        session = Waterinfo("hic", token=hic_client, cache=True)
+        session.clear_cache()
+        return session
+    else:
+        session = Waterinfo("hic", cache=True)
+        session.clear_cache()
+        return session
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,23 +3,23 @@ import time
 from pywaterinfo import Waterinfo
 
 
-def test_cache_vmm(vmm_connection):
+def test_cache_vmm(vmm_cached_connection):
     """Second call of the same request is retrieved from cache for VMM requests."""
-    vmm_connection.clear_cache()
-    data, res = vmm_connection.request_kiwis({"request": "getRequestInfo"})
+    vmm_cached_connection.clear_cache()
+    data, res = vmm_cached_connection.request_kiwis({"request": "getRequestInfo"})
     assert not res.from_cache
-    data, res = vmm_connection.request_kiwis({"request": "getRequestInfo"})
+    data, res = vmm_cached_connection.request_kiwis({"request": "getRequestInfo"})
     assert res.from_cache
 
 
-def test_cache_hic(hic_connection):
+def test_cache_hic(hic_cached_connection):
     """Second call of the same request is retrieved from cache for HIC requests."""
-    hic_connection.clear_cache()
-    data, res = hic_connection.request_kiwis(
+    hic_cached_connection.clear_cache()
+    data, res = hic_cached_connection.request_kiwis(
         query={"request": "getTimeseriesValueLayer", "timeseriesgroup_id": "156207"}
     )
     assert not res.from_cache
-    data, res = hic_connection.request_kiwis(
+    data, res = hic_cached_connection.request_kiwis(
         query={"request": "getTimeseriesValueLayer", "timeseriesgroup_id": "156207"}
     )
     assert res.from_cache
@@ -28,25 +28,24 @@ def test_cache_hic(hic_connection):
 {"request": "getTimeseriesValueLayer", "timeseriesgroup_id": "156207"}
 
 
-def test_clear_cache(vmm_connection):
+def test_clear_cache(vmm_cached_connection):
     """Cache is cleared."""
-    vmm_connection.clear_cache()
-    data, res = vmm_connection.request_kiwis({"request": "getRequestInfo"})
+    data, res = vmm_cached_connection.request_kiwis({"request": "getRequestInfo"})
     assert not res.from_cache
-    vmm_connection.clear_cache()
-    data, res = vmm_connection.request_kiwis({"request": "getRequestInfo"})
+    vmm_cached_connection.clear_cache()
+    data, res = vmm_cached_connection.request_kiwis({"request": "getRequestInfo"})
     assert not res.from_cache
 
 
 def test_cache_retention_between_sessions():
     """Requests are cached in between two sessions."""
-    vmm = Waterinfo("vmm")
+    vmm = Waterinfo("vmm", cache=True)
     vmm.clear_cache()
     _, res = vmm.request_kiwis({"request": "getRequestInfo"})
     assert not res.from_cache
 
     # New session reuses the same database
-    vmm = Waterinfo("vmm")
+    vmm = Waterinfo("vmm", cache=True)
     _, res = vmm.request_kiwis({"request": "getRequestInfo"})
     assert res.from_cache
 
@@ -64,7 +63,9 @@ def test_cache_retention(patch_retention):
     remote content has changed. Hence, we check here for expiration first, remove the
     expired cache and check for `from_cache` in a new request.
     """
-    vmm = Waterinfo("vmm")
+    # TODO - asjudt to make sure this works with the cache-header logic
+    # it will now look at cache header first with cache_control=False active
+    vmm = Waterinfo("vmm", cache=True)
     vmm.clear_cache()
     _, res = vmm.request_kiwis({"request": "getRequestInfo"})
     assert not res.from_cache

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -63,7 +63,7 @@ def test_cache_retention(patch_retention):
     remote content has changed. Hence, we check here for expiration first, remove the
     expired cache and check for `from_cache` in a new request.
     """
-    # TODO - asjudt to make sure this works with the cache-header logic
+    # TODO - adjust to make sure this works with the cache-header logic
     # it will now look at cache header first with cache_control=False active
     vmm = Waterinfo("vmm", cache=True)
     vmm.clear_cache()
@@ -75,6 +75,6 @@ def test_cache_retention(patch_retention):
     print(res.from_cache, res.created_at, res.expires, res.is_expired)
     assert res.is_expired
 
-    vmm._request.remove_expired_responses()
+    vmm._request.cache.delete(expired=True)
     _, res = vmm.request_kiwis({"request": "getRequestInfo"})
     assert not res.from_cache

--- a/tests/test_waterinfo.py
+++ b/tests/test_waterinfo.py
@@ -212,6 +212,7 @@ class TestDatetimeHandling:
         assert connection._parse_date("2017-01-01 10:00:00") == "2017-01-01 11:00:00"
         assert connection._parse_date("01-01-2017") == "2017-01-01 01:00:00"
 
+    @pytest.mark.skipif(sys.version_info < (3, 9), reason="ZoneInfo is 3.9 feature")
     def test_utc_default_return(self, connection, df_timeseries):  # noqa
         """Check that the returned dates are UTC aware and according to the user
         input in UTC
@@ -337,6 +338,7 @@ class TestDatetimeHandling:
             df_brussels["Timestamp"].dt.tz_convert("UTC"), df_utc["Timestamp"]
         )
 
+    @pytest.mark.skipif(sys.version_info < (3, 9), reason="ZoneInfo is 3.9 feature")
     def test_overwrite_timezone(self, connection, request):
         """Check if timezone is overwritten"""
         connection = request.getfixturevalue(connection)

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ passenv =
     HIC_TOKEN
     VMM_TOKEN
 extras =
+    cache
     develop
 commands =
     pytest {posargs}
@@ -52,6 +53,7 @@ setenv =
     doctests: BUILD = doctest
 extras =
     develop
+    cache
 commands =
     sphinx-build -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
 
@@ -67,6 +69,7 @@ basepython = python3
 usedevelop = true
 envdir = {toxinidir}/venv
 extras =
+    cache
     develop
 deps =
     ipykernel


### PR DESCRIPTION
This PR tackles https://github.com/fluves/pywaterinfo/issues/52:

- [x] make the cache opt-in so a user can choose to have the cache [active](https://github.com/fluves/pywaterinfo/blob/master/src/pywaterinfo/waterinfo.py#L79) or not (regular requests session). Default is no cache.
- [x] make the requests-cache an optional dependency by providing users the option to not include requests-cache on installation. pip install pywaterinfo[cache] will include the cache-dependencies.

I opted to NOT adjust the behavior in order to let individual sessions write to separate sqlite files as this partly counteracts the purpose of a cache and the default no cache behavior can be solved in situation where multiprocessing,... are important.

Apart from that:
- The cache now respects the server provided headers in the requests
- The unit tests (and fixtures) are restructured/extended to test for both cache and no-cache scenario
