### PR TITLE
Fix handling of time series with mixed timezone offsets 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/*
 .cache/*
 .*.swp
 */.ipynb_checkpoints/*
+.ipynb_checkpoints/*
 .DS_Store
 
 # Project files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,12 @@ exclude: '^docs/conf.py'
 
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.1.0
+  rev: 24.8.0
   hooks:
     - id: black
-      language_version: python3.9
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.6.0
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
@@ -24,7 +23,7 @@ repos:
     args: ['--fix=no']
 
 - repo: https://github.com/pycqa/flake8
-  rev: 6.0.0
+  rev: 7.1.1
   hooks:
   - id: flake8
     args: ['--max-line-length=88']  # default of Black

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@
     PyScaffold helps you to put up the scaffold of your new Python project.
     Learn more under: https://pyscaffold.org/
 """
+
 from setuptools import setup
 
 if __name__ == "__main__":

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -100,7 +100,7 @@ class Waterinfo:
                 self._request = requests_cache.CachedSession(
                     cache_name="pywaterinfo_cache.sqlite",
                     use_memory=False,
-                    cache_control=True,
+                    cache_control=False,
                     expire_after=CACHE_RETENTION,
                     stale_if_error=False,
                     use_cache_dir=True,

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -631,7 +631,9 @@ class Waterinfo:
                     df[key_name] = section[key_name]
             # convert datetime objects to Pandas timestamp
             if "Timestamp" in df.columns:
-                df["Timestamp"] = pd.to_datetime(df["Timestamp"])
+                # round trip via UTC to handle mixed time series
+                df["Timestamp"] = pd.to_datetime(
+                    df["Timestamp"], utc=True).dt.tz_convert(timezone)
             time_series.append(df)
 
         return pd.concat(time_series)

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -633,7 +633,8 @@ class Waterinfo:
             if "Timestamp" in df.columns:
                 # round trip via UTC to handle mixed time series
                 df["Timestamp"] = pd.to_datetime(
-                    df["Timestamp"], utc=True).dt.tz_convert(timezone)
+                    df["Timestamp"], utc=True
+                ).dt.tz_convert(timezone)
             time_series.append(df)
 
         return pd.concat(time_series)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ hic_client = os.environ.get("HIC_TOKEN")
 
 @pytest.fixture
 def patch_retention(monkeypatch):
-    retention = datetime.timedelta(seconds=0.0001)
+    retention = datetime.timedelta(seconds=2)
     monkeypatch.setattr("pywaterinfo.waterinfo.CACHE_RETENTION", retention)
 
 

--- a/tests/test_waterinfo.py
+++ b/tests/test_waterinfo.py
@@ -353,10 +353,23 @@ class TestDatetimeHandling:
             end="20190501 14:10",
             timezone="CET",
         )
-        assert is_datetime64tz_dtype(df["Timestamp"])
-        assert df["Timestamp"].dt.tz == datetime.timezone(
-            datetime.timedelta(seconds=7200)
-        )
+        assert isinstance(df["Timestamp"].dtype, pd.DatetimeTZDtype)
+        assert df["Timestamp"].dt.tz == pytz.timezone("CET")
+
+    def test_timezone_mixed_timezone(self, connection, request):
+        """Queries resulting in mixed timezone offsets are handled without warning
+
+        See also https://github.com/fluves/pywaterinfo/issues/67
+        """
+        connection = request.getfixturevalue(connection)
+        df = connection.get_timeseries_values('69928042',
+                                              start='2013-03-21 00:00:00',
+                                              end='2013-04-01 23:00:00',
+                                              timezone='CET',
+                                              returnfields="Timestamp,Value"
+                                              )
+        assert isinstance(df["Timestamp"].dtype, pd.DatetimeTZDtype)
+        assert df["Timestamp"].dt.tz == pytz.timezone("CET")
 
     def test_start_end_timezone(self, connection, request):
         """pywaterinfo can handle start/end dates already containing tz info"""

--- a/tests/test_waterinfo.py
+++ b/tests/test_waterinfo.py
@@ -362,12 +362,13 @@ class TestDatetimeHandling:
         See also https://github.com/fluves/pywaterinfo/issues/67
         """
         connection = request.getfixturevalue(connection)
-        df = connection.get_timeseries_values('69928042',
-                                              start='2013-03-21 00:00:00',
-                                              end='2013-04-01 23:00:00',
-                                              timezone='CET',
-                                              returnfields="Timestamp,Value"
-                                              )
+        df = connection.get_timeseries_values(
+            "69928042",
+            start="2013-03-21 00:00:00",
+            end="2013-04-01 23:00:00",
+            timezone="CET",
+            returnfields="Timestamp,Value",
+        )
         assert isinstance(df["Timestamp"].dtype, pd.DatetimeTZDtype)
         assert df["Timestamp"].dt.tz == pytz.timezone("CET")
 


### PR DESCRIPTION
See https://github.com/fluves/pywaterinfo/issues/67 for the discussion. This PR handles the request of a custom timezone over a period with mixed timezone offsets. Previously a warning was raised by Pandas and the timestamps were not parsed as pandas Timestamps. 