### PR TITLE
Add python 3.12/drop 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
         fail-fast: [false]
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,11 +20,11 @@ platforms = any
 classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Intended Audience :: Science/Research
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -1,5 +1,3 @@
-import pkg_resources
-
 import datetime
 import logging
 import pandas as pd
@@ -30,7 +28,6 @@ VMM_BASE = "https://download.waterinfo.be/tsmdownload/KiWIS/KiWIS"
 VMM_AUTH = "http://download.waterinfo.be/kiwis-auth/token"
 HIC_BASE = "https://hicws.vlaanderen.be/KiWIS/KiWIS"
 HIC_AUTH = "https://hicwsauth.vlaanderen.be/auth"
-DATA_PATH = pkg_resources.resource_filename(__name__, "./data")
 
 # Custom hard-coded fix for the decoding issue #1 of given returnfields
 DECODE_ERRORS = ["AV Quality Code Color", "RV Quality Code Color"]

--- a/tests/test_waterinfo.py
+++ b/tests/test_waterinfo.py
@@ -7,8 +7,6 @@ import os
 import pandas as pd
 import pytz
 import sys
-from pandas.api import types
-from pandas.api.types import is_datetime64tz_dtype
 
 from pywaterinfo import HIC_BASE, VMM_BASE, Waterinfo
 from pywaterinfo.waterinfo import WaterinfoException
@@ -217,14 +215,14 @@ class TestDatetimeHandling:
         """Check that the returned dates are UTC aware and according to the user
         input in UTC
         """
-        assert is_datetime64tz_dtype(df_timeseries["Timestamp"])
+        assert isinstance(df_timeseries["Timestamp"].dtype, pd.DatetimeTZDtype)
         assert df_timeseries.loc[0, "Timestamp"] == pd.to_datetime(
             "2019-05-01T00:00:00.000Z"
         )
         assert df_timeseries["Timestamp"].min() == pd.to_datetime(
             "2019-05-01T00:00:00.000Z"
         )
-        assert types.is_datetime64tz_dtype(pd.to_datetime(df_timeseries["Timestamp"]))
+        assert isinstance(df_timeseries["Timestamp"].dtype, pd.DatetimeTZDtype)
         assert (
             pd.to_datetime(df_timeseries.loc[0, "Timestamp"]).tz
             == datetime.timezone.utc
@@ -477,7 +475,7 @@ class TestTimeseriesValues:
         df = connection.get_timeseries_values(
             ts_id="60992042,60968042", start="20190501 14:05", end="20190501 14:10"
         )
-        assert pd.core.dtypes.common.is_datetime64tz_dtype(df["Timestamp"])
+        assert isinstance(df["Timestamp"].dtype, pd.DatetimeTZDtype)
 
 
 @pytest.mark.parametrize("connection", ["vmm_connection", "vmm_cached_connection"])

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ name = pywaterinfo
 
 [tox]
 minversion = 3.15
-envlist = py{37,38,39,310,311}
+envlist = py{38,39,310,311,312}
 skip_missing_interpreters=true
 
 


### PR DESCRIPTION
Python 3.7 is no longer a supported Python version upstream.