### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
+        python-version: ['3.10', 3.11, 3.12, 3.13]
         fail-fast: [false]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[develop,cache]
-    - name: Run precommit hooks & linting
-      if: matrix.python-version == '3.9'
-      run: |
-        python -m pip install --upgrade pre-commit
-        pre-commit run --all-files
     - name: Test with pytest when internal PR
       if: ${{ github.event.pull_request.head.repo.full_name == 'fluves/pywaterinfo' }}
       env:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,11 +20,10 @@ platforms = any
 classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Intended Audience :: Science/Research
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
@@ -41,11 +40,11 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     pandas
     requests
-    pytz
+
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.7
+python_requires = >=3.10
 
 [options.package_data]
 pywaterinfo= data/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     pandas
     requests
+    pytz
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -1,9 +1,10 @@
 import datetime
 import logging
 import pandas as pd
-import pytz
 import re
 import requests
+
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 try:
     import requests_cache
@@ -429,8 +430,10 @@ class Waterinfo:
         timezone : str, default 'UTC'
             user defined timezone to use
         """
-        if timezone not in pytz.all_timezones:
-            raise pytz.exceptions.UnknownTimeZoneError(
+        try:
+            ZoneInfo(timezone)
+        except (KeyError, ZoneInfoNotFoundError):
+            raise ZoneInfoNotFoundError(
                 f"{timezone} is not a valid timezone string."
             )
 

--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -3,8 +3,7 @@ import logging
 import pandas as pd
 import re
 import requests
-
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+from dateutil.tz import gettz
 
 try:
     import requests_cache
@@ -191,7 +190,7 @@ class Waterinfo:
             DataFrame with converted Timestamp column
         """
         df["Timestamp"] = pd.to_datetime(df["Timestamp"], utc=True).dt.tz_convert(
-            timezone
+            gettz(timezone)
         )
         return df
 
@@ -430,19 +429,16 @@ class Waterinfo:
         timezone : str, default 'UTC'
             user defined timezone to use
         """
-        try:
-            ZoneInfo(timezone)
-        except (KeyError, ZoneInfoNotFoundError):
-            raise ZoneInfoNotFoundError(
-                f"{timezone} is not a valid timezone string."
-            )
+        if gettz(timezone) is None:
+            raise ValueError(f"{timezone} is not a valid timezone string.")
 
+        tz = gettz(timezone)
         input_timestamp = pd.to_datetime(str(input_datetime))
 
         if not input_timestamp.tz:  # timestamp does not contain tz info
-            input_timestamp = input_timestamp.tz_localize(timezone)
+            input_timestamp = input_timestamp.tz_localize(tz)
 
-        return input_timestamp.tz_convert("CET").strftime("%Y-%m-%d %H:%M:%S")
+        return input_timestamp.tz_convert(gettz("CET")).strftime("%Y-%m-%d %H:%M:%S")
 
     def _parse_period(self, start=None, end=None, period=None, timezone="UTC"):
         """Check the from/to/period arguments when requesting

--- a/tests/test_waterinfo.py
+++ b/tests/test_waterinfo.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-import datetime
 import logging
 import os
 import pandas as pd
 import sys
-
-from zoneinfo import ZoneInfoNotFoundError
+from dateutil.tz import gettz
 
 from pywaterinfo import HIC_BASE, VMM_BASE, Waterinfo
 from pywaterinfo.waterinfo import WaterinfoException
@@ -211,7 +209,6 @@ class TestDatetimeHandling:
         assert connection._parse_date("2017-01-01 10:00:00") == "2017-01-01 11:00:00"
         assert connection._parse_date("01-01-2017") == "2017-01-01 01:00:00"
 
-    @pytest.mark.skipif(sys.version_info < (3, 9), reason="ZoneInfo is 3.9 feature")
     def test_utc_default_return(self, connection, df_timeseries):  # noqa
         """Check that the returned dates are UTC aware and according to the user
         input in UTC
@@ -224,10 +221,7 @@ class TestDatetimeHandling:
             "2019-05-01T00:00:00.000Z"
         )
         assert isinstance(df_timeseries["Timestamp"].dtype, pd.DatetimeTZDtype)
-        assert (
-            pd.to_datetime(df_timeseries.loc[0, "Timestamp"]).tz
-            == datetime.timezone.utc
-        )
+        assert pd.to_datetime(df_timeseries.loc[0, "Timestamp"]).tz == gettz("UTC")
 
     def test_kiwis_requires_cet(self, connection, caplog, request):
         """Check on the KIWIS behavior of CET date format as request parameter
@@ -303,7 +297,6 @@ class TestDatetimeHandling:
             df_cet["Timestamp"].dt.tz_convert("UTC"), df_utc["Timestamp"]
         )
 
-    @pytest.mark.skipif(sys.version_info < (3, 9), reason="ZoneInfo is 3.9 feature")
     def test_input_datetime_custom_timezone(self, connection, request):
         """Custom timezone with datetime input support"""
         connection = request.getfixturevalue(connection)
@@ -344,7 +337,7 @@ class TestDatetimeHandling:
         df = connection.get_timeseries_values(
             ts_id="60992042", start="20190501 14:05", end="20190501 14:10"
         )
-        assert df["Timestamp"].dt.tz == datetime.timezone.utc
+        assert df["Timestamp"].dt.tz == gettz("UTC")
 
         df = connection.get_timeseries_values(
             ts_id="60992042",
@@ -353,7 +346,7 @@ class TestDatetimeHandling:
             timezone="CET",
         )
         assert isinstance(df["Timestamp"].dtype, pd.DatetimeTZDtype)
-        assert str(df["Timestamp"].dt.tz) == "CET"
+        assert df["Timestamp"].dt.tz == gettz("CET")
 
     def test_timezone_mixed_timezone(self, connection, request):
         """Queries resulting in mixed timezone offsets are handled without warning
@@ -369,7 +362,7 @@ class TestDatetimeHandling:
             returnfields="Timestamp,Value",
         )
         assert isinstance(df["Timestamp"].dtype, pd.DatetimeTZDtype)
-        assert str(df["Timestamp"].dt.tz) == "CET"
+        assert df["Timestamp"].dt.tz == gettz("CET")
 
     def test_start_end_timezone(self, connection, request):
         """pywaterinfo can handle start/end dates already containing tz info"""
@@ -388,13 +381,13 @@ class TestDatetimeHandling:
         # datetime objects containing timezone info
         df_cet_zone = connection.get_timeseries_values(
             ts_id="60992042",
-            start=pd.to_datetime("20190501 14:05:00").tz_localize("CET"),
-            end=pd.to_datetime("20190501 14:10:00").tz_localize("CET"),
+            start=pd.to_datetime("20190501 14:05:00").tz_localize("Europe/Brussels"),
+            end=pd.to_datetime("20190501 14:10:00").tz_localize("Europe/Brussels"),
             timezone="CET",
         )
         assert df_cet_zone.loc[0, "Timestamp"] == pd.to_datetime(
             "2019-05-01 14:05:00"
-        ).tz_localize("CET")
+        ).tz_localize("Europe/Brussels")
 
         # no assumptions are made on the tz of the input dates and the requested output,
         # CET input dates with UTC output will work and return the corresponding UTC
@@ -412,7 +405,7 @@ class TestDatetimeHandling:
     def test_invalid_timezone(self, connection, request):
         """Unknown timezone should raise error"""
         connection = request.getfixturevalue(connection)
-        with pytest.raises(ZoneInfoNotFoundError):
+        with pytest.raises(ValueError):
             connection.get_timeseries_values(
                 ts_id="60992042",
                 start="20190501 14:05:00+02:00",
@@ -676,7 +669,7 @@ class TestEnsembleTimeSeries:
         )
 
         assert isinstance(data, pd.DataFrame)
-        assert data["Timestamp"].dt.tz.zone == tz
+        assert data["Timestamp"].dt.tz == gettz(tz)
         assert not data.empty
 
     @pytest.mark.parametrize("connection", ["hic_connection", "hic_cached_connection"])
@@ -690,7 +683,7 @@ class TestEnsembleTimeSeries:
         )
 
         assert isinstance(data, pd.DataFrame)
-        assert data["Timestamp"].dt.tz == datetime.timezone.utc
+        assert data["Timestamp"].dt.tz == gettz("UTC")
 
     @pytest.mark.parametrize("connection", ["hic_connection", "hic_cached_connection"])
     def test_cannot_have_two_identifiers(self, connection, request):

--- a/tests/test_waterinfo.py
+++ b/tests/test_waterinfo.py
@@ -5,8 +5,9 @@ import datetime
 import logging
 import os
 import pandas as pd
-import pytz
 import sys
+
+from zoneinfo import ZoneInfoNotFoundError
 
 from pywaterinfo import HIC_BASE, VMM_BASE, Waterinfo
 from pywaterinfo.waterinfo import WaterinfoException
@@ -278,7 +279,7 @@ class TestDatetimeHandling:
         provided by the user.
 
         Note, there is no query option to check the timezone string for the java
-        app of kisters, so we only check if string is supported by pytz.
+        app of kisters, so we only check if string is supported by zoneinfo.
         """
         connection = request.getfixturevalue(connection)
         df_utc_default = connection.get_timeseries_values(
@@ -411,7 +412,7 @@ class TestDatetimeHandling:
     def test_invalid_timezone(self, connection, request):
         """Unknown timezone should raise error"""
         connection = request.getfixturevalue(connection)
-        with pytest.raises(pytz.exceptions.UnknownTimeZoneError):
+        with pytest.raises(ZoneInfoNotFoundError):
             connection.get_timeseries_values(
                 ts_id="60992042",
                 start="20190501 14:05:00+02:00",

--- a/tests/test_waterinfo.py
+++ b/tests/test_waterinfo.py
@@ -352,7 +352,7 @@ class TestDatetimeHandling:
             timezone="CET",
         )
         assert isinstance(df["Timestamp"].dtype, pd.DatetimeTZDtype)
-        assert df["Timestamp"].dt.tz == pytz.timezone("CET")
+        assert str(df["Timestamp"].dt.tz) == "CET"
 
     def test_timezone_mixed_timezone(self, connection, request):
         """Queries resulting in mixed timezone offsets are handled without warning
@@ -368,7 +368,7 @@ class TestDatetimeHandling:
             returnfields="Timestamp,Value",
         )
         assert isinstance(df["Timestamp"].dtype, pd.DatetimeTZDtype)
-        assert df["Timestamp"].dt.tz == pytz.timezone("CET")
+        assert str(df["Timestamp"].dt.tz) == "CET"
 
     def test_start_end_timezone(self, connection, request):
         """pywaterinfo can handle start/end dates already containing tz info"""

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ name = pywaterinfo
 
 [tox]
 minversion = 3.15
-envlist = py{311,312,313}
+envlist = py{310,311,312,313}
 skip_missing_interpreters=true
 
 
@@ -68,7 +68,7 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:dev]
 description = Create development environment with venv and register ipykernel
-basepython = python3.11
+basepython = python3.13
 usedevelop = true
 envdir = {toxinidir}/venv
 extras =
@@ -77,4 +77,4 @@ extras =
 deps =
     ipykernel
 commands =
-    python -m ipykernel install --user --name {[main]name} --display-name 'Python 3.11 ({[main]name})'
+    python -m ipykernel install --user --name {[main]name} --display-name 'Python 3.13 ({[main]name})'

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ name = pywaterinfo
 
 [tox]
 minversion = 3.15
-envlist = py{38,39,310,311,312}
+envlist = py{311,312,313}
 skip_missing_interpreters=true
 
 
@@ -68,7 +68,7 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:dev]
 description = Create development environment with venv and register ipykernel
-basepython = python3
+basepython = python3.11
 usedevelop = true
 envdir = {toxinidir}/venv
 extras =
@@ -77,4 +77,4 @@ extras =
 deps =
     ipykernel
 commands =
-    python -m ipykernel install --user --name {[main]name} --display-name 'Python py39 ({[main]name})'
+    python -m ipykernel install --user --name {[main]name} --display-name 'Python 3.11 ({[main]name})'


### PR DESCRIPTION
I think `pytz` is not installed by default (or it was dependency of something else) with the recent python versions. In any case, now it is not possible import package

```zsh
baris@laptop043 ~/dev/pywaterinfo (master) $ tox -e dev
.pkg: _optional_hooks> python /home/baris/.local/share/uv/tools/tox/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: get_requires_for_build_sdist> python /home/baris/.local/share/uv/tools/tox/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: get_requires_for_build_editable> python /home/baris/.local/share/uv/tools/tox/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: build_editable> python /home/baris/.local/share/uv/tools/tox/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta
dev: install_package> python -I -m pip install --force-reinstall --no-deps /home/baris/dev/pywaterinfo/.tox/.tmp/package/5/pywaterinfo-0.0.post1.dev249+g9e820ee65-0.editable-py2.py3-none-any.whl
dev: commands[0]> python -m ipykernel install --user --name pywaterinfo --display-name 'Python py39 (pywaterinfo)'
Installed kernelspec pywaterinfo in /home/baris/.local/share/jupyter/kernels/pywaterinfo
  dev: OK (1.30=setup[1.01]+cmd[0.29] seconds)
  congratulations :) (1.33 seconds)
baris@laptop043 ~/dev/pywaterinfo (master) $ source ./venv/bin/activate       
(venv) baris@laptop043 ~/dev/pywaterinfo (master) $ p
(venv) baris@laptop043 ~/dev/pywaterinfo (master) $ pytest
ImportError while loading conftest '/home/baris/dev/pywaterinfo/tests/conftest.py'.
tests/conftest.py:10: in <module>
    from pywaterinfo.waterinfo import Waterinfo
src/pywaterinfo/__init__.py:3: in <module>
    from .waterinfo import HIC_BASE, VMM_BASE, Waterinfo
src/pywaterinfo/waterinfo.py:4: in <module>
    import pytz
E   ModuleNotFoundError: No module named 'pytz'
```

Also, asserting two datetime objects from pandas and pytz was failing.