### PR TITLE
Add decode_errors field to provider registry to avoid impact on all providers

### DIFF
--- a/src/pywaterinfo/waterinfo.py
+++ b/src/pywaterinfo/waterinfo.py
@@ -43,26 +43,27 @@ PROVIDERS = {
         "base_url": VMM_BASE,
         "auth_url": VMM_AUTH,
         "datasource": "1",
+        "decode_errors": ["AV Quality Code Color", "RV Quality Code Color"],
     },
     "hic": {
         "base_url": HIC_BASE,
         "auth_url": HIC_AUTH,
         "datasource": "4",
+        "decode_errors": ["AV Quality Code Color", "RV Quality Code Color"],
     },
     "vmm_grid": {
         "base_url": VMM_GRID_BASE,
         "auth_url": VMM_GRID_AUTH,
         "datasource": "10",
+        "decode_errors": ["AV Quality Code Color", "RV Quality Code Color"],
     },
     "spw": {
         "base_url": SPW_BASE,
         "auth_url": SPW_AUTH,
         "datasource": "0",
+        "decode_errors": ["Parameter Comment"],
     },
 }
-
-# Custom hard-coded fix for the decoding issue #1 of given returnfields
-DECODE_ERRORS = ["AV Quality Code Color", "RV Quality Code Color"]
 
 # Default cache configuration
 CACHE_RETENTION = datetime.timedelta(days=7)
@@ -119,6 +120,7 @@ class Waterinfo:
         self._base_url = PROVIDERS[provider]["base_url"]
         self._auth_url = PROVIDERS[provider]["auth_url"]
         self._datasource = PROVIDERS[provider]["datasource"]
+        self._decode_errors = PROVIDERS[provider]["decode_errors"]
         # Use requests-cache session
         if cache:
             if request_cache_support:
@@ -668,7 +670,7 @@ class Waterinfo:
             "Content"
         ].keys()
         all_returnfields = [
-            field for field in returnfields if field not in DECODE_ERRORS
+            field for field in returnfields if field not in self._decode_errors
         ]
 
         query_param = dict(

--- a/tests/test_waterinfo.py
+++ b/tests/test_waterinfo.py
@@ -469,8 +469,8 @@ class TestDatetimeHandling:
             connection._check_return_fields_format("DUMMY,DUMMY")
 
 
-@pytest.mark.parametrize("connection", ["vmm_connection", "vmm_cached_connection"])
 class TestTimeseriesValues:
+    @pytest.mark.parametrize("connection", ["vmm_connection", "vmm_cached_connection"])
     def test_one_of_two_ids(self, connection, request):
         """either ts_id or timeseriesgroup_id should be used"""
         connection = request.getfixturevalue(connection)
@@ -481,6 +481,7 @@ class TestTimeseriesValues:
         with pytest.raises(Exception):
             connection.get_timeseries_values(period="P1D")
 
+    @pytest.mark.parametrize("connection", ["vmm_connection", "vmm_cached_connection"])
     def test_multiple_ids(self, connection, request):
         """Call worksxpected for multiple identifiers combined in single dataframe"""
         """either ts_id or timeseriesgroup_id should be used"""
@@ -490,6 +491,7 @@ class TestTimeseriesValues:
         )
         assert set(df["ts_id"].unique()) == set(["60992042", "60968042"])
 
+    @pytest.mark.parametrize("connection", ["vmm_connection", "vmm_cached_connection"])
     def test_no_data(self, connection, request):
         """return empty dataframe when no data"""
         connection = request.getfixturevalue(connection)
@@ -504,12 +506,21 @@ class TestTimeseriesValues:
         )
         assert len(df) == 0
 
+    @pytest.mark.parametrize("connection", ["vmm_connection", "vmm_cached_connection"])
     def test_datetime_conversion(self, connection, request):
         """Datetime in the returned data sets are pd.Timestamps with timezone info"""
         connection = request.getfixturevalue(connection)
         df = connection.get_timeseries_values(
             ts_id="60992042,60968042", start="20190501 14:05", end="20190501 14:10"
         )
+        assert isinstance(df["Timestamp"].dtype, pd.DatetimeTZDtype)
+
+    @pytest.mark.parametrize("connection", ["spw_connection", "spw_cached_connection"])
+    def test_spw_timeseries_values(self, connection, request):
+        """Datetime in the returned data sets are pd.Timestamps with timezone info"""
+        connection = request.getfixturevalue(connection)
+        df = connection.get_timeseries_values(ts_id="235519010", period="P1D")
+
         assert isinstance(df["Timestamp"].dtype, pd.DatetimeTZDtype)
 
 


### PR DESCRIPTION
decode_errors is now added to the provider registry. This allows more fine-grained control of the decode errors for the different providers, avoiding that errors for one provider impact all the others.

This PR fixes #78 and also adds a test for get_timeseries_values for spw provider.

